### PR TITLE
feat: add support for http basic authentication

### DIFF
--- a/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
@@ -55,7 +55,7 @@ namespace Serilog
 				throw new ArgumentNullException(nameof(sinkConfiguration));
 
 			var sink = new HttpSink(
-				httpClient ?? new HttpClientWrapper(),
+				httpClient ?? new HttpClientWrapper(options.User, options.Password),
 				requestUri,
 				options);
 
@@ -90,7 +90,7 @@ namespace Serilog
 				throw new ArgumentNullException(nameof(sinkConfiguration));
 
 			var sink = new DurableHttpSink(
-				httpClient ?? new HttpClientWrapper(),
+				httpClient ?? new HttpClientWrapper(options.User, options.Password),
 				requestUri,
 				options);
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Options.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Options.cs
@@ -45,5 +45,15 @@ namespace Serilog.Sinks.Http
 		/// <see cref="Http.FormattingType.NormalRendered"/>.
 		/// </summary>
 		public FormattingType FormattingType { get; set; } = FormattingType.NormalRendered;
+
+		/// <summary>
+		/// Gets or sets the basic authentication user. Default value is empty string
+		/// </summary>
+		public String User { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the basic authentication password. Default value is empty string
+		/// </summary>
+		public String Password { get; set; } = string.Empty;
 	}
 }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Http/HttpClientWrapper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Http/HttpClientWrapper.cs
@@ -21,9 +21,16 @@ namespace Serilog.Sinks.Http.Private.Http
 	{
 		private readonly HttpClient client;
 
-		public HttpClientWrapper()
+		public HttpClientWrapper(string user, string password)
 		{
 			client = new HttpClient();
+
+			if (user != "" && password != "")
+			{
+				var credentials = System.Text.Encoding.ASCII.GetBytes(user + ":" + password);
+				client.DefaultRequestHeaders.Authorization =
+					new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", System.Convert.ToBase64String(credentials));
+			}
 		}
 
 		public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)


### PR DESCRIPTION
Added support for basic authentication. Could also be implemented as generic http header option, like https://github.com/serilog/serilog-sinks-elasticsearch/pull/90/commits/317ee59772fbf959b9efbf95d9c12fb4739c4c5e.