### PR TITLE
Partially written log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :syringe: Fixed
+
+- [#54](https://github.com/FantasticFiasco/serilog-sinks-http/issues/54) Prevent durable HTTP sink from posting partially written log events
+
 ## [5.0.0] - 2018-08-30
 
 ### :zap: Added

--- a/serilog-sinks-http.sln.DotSettings
+++ b/serilog-sinks-http.sln.DotSettings
@@ -118,7 +118,9 @@
 	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=WrapInRegion/@EntryIndexedValue">False</s:String>
 	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=XmlDocumentation/@EntryIndexedValue">False</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CF/@EntryIndexedValue">CF</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CR/@EntryIndexedValue">CR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LF/@EntryIndexedValue">LF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>

--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <AssemblyName>Serilog.Sinks.Http</AssemblyName>
     <Description>A Serilog sink sending log events over HTTP.</Description>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>

--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <AssemblyName>Serilog.Sinks.Http</AssemblyName>
     <Description>A Serilog sink sending log events over HTTP.</Description>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
@@ -40,14 +40,14 @@ namespace Serilog.Sinks.Http.Private.Network
 
             if (fileStream.Length != 0)
             {
-                // Important not to dispose this StreamReader as the stream must remain open.
+                // Important not to dispose this StreamReader as the stream must remain open
                 var reader = new StreamReader(fileStream, Encoding.UTF8, false, 128);
-                var current = reader.ReadLine();
+                var bookmark = reader.ReadLine();
 
-                if (current != null)
+                if (bookmark != null)
                 {
                     fileStream.Position = 0;
-                    var parts = current.Split(
+                    var parts = bookmark.Split(
                         new[] { ":::" },
                         StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
@@ -1,10 +1,24 @@
-﻿using System;
+﻿// Copyright 2015-2018 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System;
 using System.IO;
 using System.Text;
 
 namespace Serilog.Sinks.Http.Private.Network
 {
-    internal class BookmarkFile : IDisposable
+    public class BookmarkFile : IDisposable
     {
         private readonly FileStream fileStream;
 
@@ -57,3 +71,4 @@ namespace Serilog.Sinks.Http.Private.Network
         public void Dispose() => fileStream?.Dispose();
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/BookmarkFile.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.Http.Private.Network
+{
+    internal class BookmarkFile : IDisposable
+    {
+        private readonly FileStream fileStream;
+
+        public BookmarkFile(string bookmarkFilename)
+        {
+            if (bookmarkFilename == null) throw new ArgumentNullException(nameof(bookmarkFilename));
+
+            fileStream = System.IO.File.Open(
+                bookmarkFilename,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.Read);
+        }
+        
+        public void TryReadBookmark(out long nextLineBeginsAtOffset, out string currentFile)
+        {
+            nextLineBeginsAtOffset = 0;
+            currentFile = null;
+
+            if (fileStream.Length != 0)
+            {
+                // Important not to dispose this StreamReader as the stream must remain open.
+                var reader = new StreamReader(fileStream, Encoding.UTF8, false, 128);
+                var current = reader.ReadLine();
+
+                if (current != null)
+                {
+                    fileStream.Position = 0;
+                    var parts = current.Split(
+                        new[] { ":::" },
+                        StringSplitOptions.RemoveEmptyEntries);
+
+                    if (parts.Length == 2)
+                    {
+                        nextLineBeginsAtOffset = long.Parse(parts[0]);
+                        currentFile = parts[1];
+                    }
+                }
+            }
+        }
+
+        public void WriteBookmark(long nextLineBeginsAtOffset, string currentFile)
+        {
+            using (var writer = new StreamWriter(fileStream))
+            {
+                writer.WriteLine("{0}:::{1}", nextLineBeginsAtOffset, currentFile);
+            }
+        }
+
+        public void Dispose() => fileStream?.Dispose();
+    }
+}

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DateFormats.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DateFormats.cs
@@ -1,9 +1,24 @@
-﻿namespace Serilog.Sinks.Http.Private.Network
+﻿// Copyright 2015-2018 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Serilog.Sinks.Http.Private.Network
 {
-    internal enum DateFormats
+    public enum DateFormats
     {
         Date,
         Hour,
         HalfHour
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DefaultHttpClient.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DefaultHttpClient.cs
@@ -11,13 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Serilog.Sinks.Http.Private.Network
 {
-    internal class DefaultHttpClient : IHttpClient
+    public class DefaultHttpClient : IHttpClient
     {
         private readonly HttpClient client;
 
@@ -31,3 +31,4 @@ namespace Serilog.Sinks.Http.Private.Network
             client.Dispose();
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System;
 using System.IO;
 using System.Linq;
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 
 namespace Serilog.Sinks.Http.Private.Network
 {
-    internal class HttpLogShipper : IDisposable
+    public class HttpLogShipper : IDisposable
     {
         private const string ContentType = "application/json";
 
@@ -261,3 +261,4 @@ namespace Serilog.Sinks.Http.Private.Network
         }
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
@@ -22,7 +22,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Sinks.Http.Private.Time;
-using IOFile = System.IO.File;
 #if HRESULTS
 using System.Runtime.InteropServices;
 #endif
@@ -118,7 +117,7 @@ namespace Serilog.Sinks.Http.Private.Network
 
                         var fileSet = GetFileSet();
 
-                        if (currentFile == null || !IOFile.Exists(currentFile))
+                        if (currentFile == null || !System.IO.File.Exists(currentFile))
                         {
                             nextLineBeginsAtOffset = 0;
                             currentFile = fileSet.FirstOrDefault();
@@ -180,7 +179,7 @@ namespace Serilog.Sinks.Http.Private.Network
                                 // Once there's a third file waiting to ship, we do our
                                 // best to move on, though a lock on the current file
                                 // will delay this.
-                                IOFile.Delete(fileSet[0]);
+                                System.IO.File.Delete(fileSet[0]);
                             }
                         }
                     }
@@ -207,7 +206,7 @@ namespace Serilog.Sinks.Http.Private.Network
         {
             var events = new List<string>();
 
-            using (var current = IOFile.Open(currentFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var current = System.IO.File.Open(currentFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 current.Position = nextLineBeginsAtOffset;
 
@@ -233,7 +232,7 @@ namespace Serilog.Sinks.Http.Private.Network
         {
             try
             {
-                using (var fileStream = IOFile.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+                using (var fileStream = System.IO.File.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
                 {
                     return fileStream.Length <= maxLength;
                 }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -108,9 +107,6 @@ namespace Serilog.Sinks.Http.Private.Network
                 {
                     count = 0;
 
-                    // Locking the bookmark ensures that though there may be multiple instances of this
-                    // class running, only one will ship logs at a time.
-
                     using (var bookmark = new BookmarkFile(bookmarkFilename))
                     {
                         bookmark.TryReadBookmark(out var nextLineBeginsAtOffset, out var currentFile);
@@ -126,7 +122,12 @@ namespace Serilog.Sinks.Http.Private.Network
                         if (currentFile == null)
                             continue;
 
-                        var payload = ReadPayload(currentFile, ref nextLineBeginsAtOffset, ref count);
+                        var payload = PayloadReader.Read(
+                            currentFile,
+                            ref nextLineBeginsAtOffset,
+                            ref count,
+                            batchFormatter,
+                            batchPostingLimit);
 
                         if (count > 0 || nextRequiredLevelCheckUtc < DateTime.UtcNow)
                         {
@@ -202,32 +203,6 @@ namespace Serilog.Sinks.Http.Private.Network
             }
         }
 
-        private string ReadPayload(string currentFile, ref long nextLineBeginsAtOffset, ref int count)
-        {
-            var events = new List<string>();
-
-            using (var current = System.IO.File.Open(currentFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            {
-                current.Position = nextLineBeginsAtOffset;
-
-                while (count < batchPostingLimit &&
-                       TryReadLine(current, ref nextLineBeginsAtOffset, out var nextLine))
-                {
-                    // Count is the indicator that work was done, so advances even in the (rare) case an
-                    // oversized event is dropped
-                    count++;
-
-                    events.Add(nextLine);
-                }
-            }
-
-            var payload = new StringWriter();
-
-            batchFormatter.Format(events, payload);
-
-            return payload.ToString();
-        }
-
         private static bool IsUnlockedAtLength(string file, long maxLength)
         {
             try
@@ -258,33 +233,6 @@ namespace Serilog.Sinks.Http.Private.Network
             }
 
             return false;
-        }
-
-        // It would be ideal to chomp whitespace here, but not required
-        private static bool TryReadLine(Stream current, ref long nextStart, out string nextLine)
-        {
-            var includesBom = nextStart == 0;
-
-            if (current.Length <= nextStart)
-            {
-                nextLine = null;
-                return false;
-            }
-
-            current.Position = nextStart;
-
-            // Important not to dispose this StreamReader as the stream must remain open.
-            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
-            nextLine = reader.ReadLine();
-
-            if (nextLine == null)
-                return false;
-
-            nextStart += Encoding.UTF8.GetByteCount(nextLine) + Encoding.UTF8.GetByteCount(Environment.NewLine);
-            if (includesBom)
-                nextStart += 3;
-
-            return true;
         }
 
         private string[] GetFileSet()

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/HttpLogShipper.cs
@@ -122,13 +122,16 @@ namespace Serilog.Sinks.Http.Private.Network
                         if (currentFile == null)
                             continue;
 
-                        var payload = PayloadReader.Read(
+                        var logEvents = PayloadReader.Read(
                             currentFile,
                             ref nextLineBeginsAtOffset,
                             ref count,
-                            batchFormatter,
                             batchPostingLimit);
 
+                        var payloadWriter = new StringWriter();
+                        batchFormatter.Format(logEvents, payloadWriter);
+                        var payload = payloadWriter.ToString();
+                        
                         if (count > 0 || nextRequiredLevelCheckUtc < DateTime.UtcNow)
                         {
                             lock (stateLock)

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -97,7 +97,7 @@ namespace Serilog.Sinks.Http.Private.Network
                 var character = reader.Read();
 
                 // Is this the end of the stream? In that case abort since all log events should be
-                // terminated using a new line, and a line without a new line this would mean that
+                // terminated using a new line, and a line without a new line would mean that
                 // either:
                 //   - There are no new log events
                 //   - The current log event hasn't yet been completely flushed to disk 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -50,9 +50,7 @@ namespace Serilog.Sinks.Http.Private.Network
 
             current.Position = nextStart;
 
-            // Important not to dispose this StreamReader as the stream must remain open.
-            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
-            nextLine = reader.ReadLine();
+            nextLine = ReadLine(current);
 
             if (nextLine == null)
                 return false;
@@ -65,6 +63,32 @@ namespace Serilog.Sinks.Http.Private.Network
             }
 
             return true;
+        }
+
+        private static string ReadLine(Stream current)
+        {
+            // Important not to dispose this StreamReader as the stream must remain open.
+            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+
+            var stringBuilder = new StringBuilder();
+
+            while (true)
+            {
+                var x = reader.Read();
+
+                if (x == -1)
+                {
+                    return null;
+                }
+
+                if (x == '\r' || x == '\n')
+                {
+                    return stringBuilder.ToString();
+                    
+                }
+
+                stringBuilder.Append((char)x);
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Serilog.Sinks.Http.Private.Network
+{
+    internal static class PayloadReader
+    {
+        public static string Read(
+            string currentFile,
+            ref long nextLineBeginsAtOffset,
+            ref int count,
+            IBatchFormatter batchFormatter,
+            int batchPostingLimit)
+        {
+            var events = new List<string>();
+
+            using (var current = System.IO.File.Open(currentFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                current.Position = nextLineBeginsAtOffset;
+
+                while (count < batchPostingLimit &&
+                       TryReadLine(current, ref nextLineBeginsAtOffset, out var nextLine))
+                {
+                    // Count is the indicator that work was done, so advances even in the (rare) case an
+                    // oversized event is dropped
+                    count++;
+
+                    events.Add(nextLine);
+                }
+            }
+
+            var payload = new StringWriter();
+
+            batchFormatter.Format(events, payload);
+
+            return payload.ToString();
+        }
+
+        private static bool TryReadLine(Stream current, ref long nextStart, out string nextLine)
+        {
+            var includesBom = nextStart == 0;
+
+            if (current.Length <= nextStart)
+            {
+                nextLine = null;
+                return false;
+            }
+
+            current.Position = nextStart;
+
+            // Important not to dispose this StreamReader as the stream must remain open.
+            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+            nextLine = reader.ReadLine();
+
+            if (nextLine == null)
+                return false;
+
+            nextStart += Encoding.UTF8.GetByteCount(nextLine) + Encoding.UTF8.GetByteCount(Environment.NewLine);
+
+            if (includesBom)
+            {
+                nextStart += 3;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -90,15 +90,15 @@ namespace Serilog.Sinks.Http.Private.Network
         {
             // Important not to dispose this StreamReader as the stream must remain open
             var reader = new StreamReader(stream, Encoding.UTF8, false, 128);
-
             var lineBuilder = new StringBuilder();
 
             while (true)
             {
-                var character = (char)reader.Read();
+                var character = reader.Read();
 
-                // Is this the end of the stream? In that case abort since all log events are
-                // terminated using a new line, and this would mean that either:
+                // Is this the end of the stream? In that case abort since all log events should be
+                // terminated using a new line, and a line without a new line this would mean that
+                // either:
                 //   - There are no new log events
                 //   - The current log event hasn't yet been completely flushed to disk 
                 if (character == -1)
@@ -112,7 +112,7 @@ namespace Serilog.Sinks.Http.Private.Network
                     return lineBuilder.ToString();
                 }
 
-                lineBuilder.Append(character);
+                lineBuilder.Append((char)character);
             }
         }
     }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -1,11 +1,25 @@
-﻿using System;
+﻿// Copyright 2015-2018 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
 namespace Serilog.Sinks.Http.Private.Network
 {
-    internal static class PayloadReader
+    public static class PayloadReader
     {
         private const char CR = '\r';
         private const char LF = '\n';
@@ -103,3 +117,4 @@ namespace Serilog.Sinks.Http.Private.Network
         }
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -7,8 +7,8 @@ namespace Serilog.Sinks.Http.Private.Network
 {
     internal static class PayloadReader
     {
-        private const string CR = '\r';
-        private const string LF = '\n';
+        private const char CR = '\r';
+        private const char LF = '\n';
 
         public static string Read(
             string fileName,
@@ -31,11 +31,11 @@ namespace Serilog.Sinks.Http.Private.Network
             int batchPostingLimit)
         {
             var events = new List<string>();
-            
-            current.Position = nextLineBeginsAtOffset;
+
+            stream.Position = nextLineBeginsAtOffset;
 
             while (count < batchPostingLimit &&
-                    TryReadLine(current, ref nextLineBeginsAtOffset, out var nextLine))
+                    TryReadLine(stream, ref nextLineBeginsAtOffset, out var nextLine))
             {
                 // Count is the indicator that work was done, so advances even in the (rare) case an
                 // oversized event is dropped
@@ -78,18 +78,16 @@ namespace Serilog.Sinks.Http.Private.Network
             return true;
         }
 
-        private static string ReadLine(Stream current)
+        private static string ReadLine(Stream stream)
         {
             // Important not to dispose this StreamReader as the stream must remain open
-            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+            var reader = new StreamReader(stream, Encoding.UTF8, false, 128);
 
             var lineBuilder = new StringBuilder();
 
-            char character;
-
             while (true)
             {
-                character = reader.Read();
+                var character = (char)reader.Read();
 
                 // Is this the end of the stream? In that case abort since all log events are
                 // terminated using a new line, and this would mean that either:

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/PayloadReader.cs
@@ -10,27 +10,25 @@ namespace Serilog.Sinks.Http.Private.Network
         private const char CR = '\r';
         private const char LF = '\n';
 
-        public static string Read(
+        public static string[] Read(
             string fileName,
             ref long nextLineBeginsAtOffset,
             ref int count,
-            IBatchFormatter batchFormatter,
             int batchPostingLimit)
         {
             using (var stream = System.IO.File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
-                return Read(stream, ref nextLineBeginsAtOffset, ref count, batchFormatter, batchPostingLimit);
+                return Read(stream, ref nextLineBeginsAtOffset, ref count, batchPostingLimit);
             }
         }
 
-        public static string Read(
+        public static string[] Read(
             Stream stream,
             ref long nextLineBeginsAtOffset,
             ref int count,
-            IBatchFormatter batchFormatter,
             int batchPostingLimit)
         {
-            var events = new List<string>();
+            var logEvents = new List<string>();
 
             stream.Position = nextLineBeginsAtOffset;
 
@@ -41,14 +39,10 @@ namespace Serilog.Sinks.Http.Private.Network
                 // oversized event is dropped
                 count++;
 
-                events.Add(nextLine);
+                logEvents.Add(nextLine);
             }
 
-            var payload = new StringWriter();
-
-            batchFormatter.Format(events, payload);
-
-            return payload.ToString();
+            return logEvents.ToArray();
         }
 
         private static bool TryReadLine(Stream current, ref long nextStart, out string nextLine)

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Sinks/HttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Sinks/HttpSink.cs
@@ -88,9 +88,9 @@ namespace Serilog.Sinks.Http.Private.Sinks
         /// <summary>
         /// Emit a batch of log events, running asynchronously.
         /// </summary>
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> logEvents)
         {
-            var payload = FormatPayload(events);
+            var payload = FormatPayload(logEvents);
             var content = new StringContent(payload, Encoding.UTF8, ContentType);
 
             var result = await client
@@ -121,11 +121,11 @@ namespace Serilog.Sinks.Http.Private.Sinks
             }
         }
 
-        private string FormatPayload(IEnumerable<LogEvent> events)
+        private string FormatPayload(IEnumerable<LogEvent> logEvents)
         {
             var payload = new StringWriter();
 
-            batchFormatter.Format(events, textFormatter, payload);
+            batchFormatter.Format(logEvents, textFormatter, payload);
 
             return payload.ToString();
         }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Time/ExponentialBackoffConnectionSchedule.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Time/ExponentialBackoffConnectionSchedule.cs
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System;
 
 namespace Serilog.Sinks.Http.Private.Time
 {
-    internal class ExponentialBackoffConnectionSchedule
+    public class ExponentialBackoffConnectionSchedule
     {
         private static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
@@ -71,3 +71,4 @@ namespace Serilog.Sinks.Http.Private.Time
         }
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Time/PortableTimer.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Time/PortableTimer.cs
@@ -11,14 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Serilog.Sinks.Http.Private.Time
 {
-    internal class PortableTimer : IDisposable
+    public class PortableTimer : IDisposable
     {
         private readonly object stateLock = new object();
         private readonly Func<Task> onTick;
@@ -109,3 +109,4 @@ namespace Serilog.Sinks.Http.Private.Time
         }
     }
 }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
@@ -1,43 +1,103 @@
-//using System.IO;
-//using Xunit;
+using System;
+using System.IO;
+using System.Text;
+using Shouldly;
+using Xunit;
 
-//namespace Serilog.Sinks.Http.Private.Network
-//{
-//    public class PayloadReaderShould
-//    {
-//        private long nextLineBeginsAtOffset;
-//        private int count;
+namespace Serilog.Sinks.Http.Private.Network
+{
+    public class PayloadReaderShould
+    {
+        private const string Foo = "{ \"foo\": 1 }";
+        private const string Bar = "{ \"bar\": 2 }";
 
-//        [Fact]
-//        public void ReadLogEvent()
-//        {
-//            // Arrange
-//            var stream = new MemoryStream("{ \"foo\": 1 }");
+        private long nextLineBeginsAtOffset = 1;    // Start at offset 1 to get around the issue with BOM
+        private int count;
 
-//            // Act
-//            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, null, int.MaxValue);
+        [Fact]
+        public void ReadLogEvent()
+        {
+            // Arrange
+            var expected = new[] { Foo };
 
-//            // Assert
-//            //actual.
-//            count.ShouldBe()
-//        }
+            var fileContent =
+                " " +   // Adapt to offset 1
+                expected[0] + Environment.NewLine;
 
-//        [Fact]
-//        public void ReadLogEvents()
-//        {
-            
-//        }
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
 
-//        [Fact]
-//        public void NotReadEventGivenPartiallyWritten()
-//        {
-            
-//        }
+            // Act
+            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
 
-//        [Fact]
-//        public void NotReadEventsGivenPartiallyWritten()
-//        {
-            
-//        }
-//    }
-//}
+            // Assert
+            actual.ShouldBe(expected);
+            nextLineBeginsAtOffset.ShouldBe(fileContent.Length);
+            count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void NotReadLogEventGivenPartiallyWritten()
+        {
+            // Arrange
+            var expected = new string[0];
+
+            var fileContent =
+                " " +   // Adapt to offset 1
+                Foo;    // Partially written log event since new line is missing
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
+
+            // Act
+            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
+
+            // Assert
+            actual.ShouldBe(expected);
+            nextLineBeginsAtOffset.ShouldBe(1);
+            count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void ReadLogEvents()
+        {
+            // Arrange
+            var expected = new[] { Foo, Bar };
+
+            var fileContent =
+                " " +   // Adapt to offset 1
+                expected[0] + Environment.NewLine +
+                expected[1] + Environment.NewLine;
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
+
+            // Act
+            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
+
+            // Assert
+            actual.ShouldBe(expected);
+            nextLineBeginsAtOffset.ShouldBe(fileContent.Length);
+            count.ShouldBe(2);
+        }
+        
+        [Fact]
+        public void NotReadEventsGivenPartiallyWritten()
+        {
+            // Arrange
+            var expected = new[] { Foo };
+
+            var fileContent =
+                " " +           // Adapt to offset 1
+                expected[0] + Environment.NewLine +
+                Bar;    // Partially written log event since new line is missing
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
+
+            // Act
+            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
+
+            // Assert
+            actual.ShouldBe(expected);
+            nextLineBeginsAtOffset.ShouldBe(fileContent.IndexOf(Bar, StringComparison.InvariantCulture));
+            count.ShouldBe(1);
+        }
+    }
+}

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
@@ -1,40 +1,43 @@
-namespace Serilog.Sinks.Http.Private.Network
-{
-    public class PayloadReaderShould
-    {
-        private long nextLineBeginsAtOffset;
-        private int count;
+//using System.IO;
+//using Xunit;
 
-        [Fact]
-        public void ReadLogEvent()
-        {
-            // Arrange
-            var stream = new MemoryStream("{ \"foo\": 1 }");
+//namespace Serilog.Sinks.Http.Private.Network
+//{
+//    public class PayloadReaderShould
+//    {
+//        private long nextLineBeginsAtOffset;
+//        private int count;
 
-            // Act
-            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, null, int.MaxValue);
+//        [Fact]
+//        public void ReadLogEvent()
+//        {
+//            // Arrange
+//            var stream = new MemoryStream("{ \"foo\": 1 }");
 
-            // Assert
-            //actual.
-            count.ShouldBe()
-        }
+//            // Act
+//            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, null, int.MaxValue);
 
-        [Fact]
-        public void ReadLogEvents()
-        {
+//            // Assert
+//            //actual.
+//            count.ShouldBe()
+//        }
+
+//        [Fact]
+//        public void ReadLogEvents()
+//        {
             
-        }
+//        }
 
-        [Fact]
-        public void NotReadEventGivenPartiallyWritten()
-        {
+//        [Fact]
+//        public void NotReadEventGivenPartiallyWritten()
+//        {
             
-        }
+//        }
 
-        [Fact]
-        public void NotReadEventsGivenPartiallyWritten()
-        {
+//        [Fact]
+//        public void NotReadEventsGivenPartiallyWritten()
+//        {
             
-        }
-    }
-}
+//        }
+//    }
+//}

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
@@ -1,0 +1,40 @@
+namespace Serilog.Sinks.Http.Private.Network
+{
+    public class PayloadReaderShould
+    {
+        private long nextLineBeginsAtOffset;
+        private int count;
+
+        [Fact]
+        public void ReadLogEvent()
+        {
+            // Arrange
+            var stream = new MemoryStream("{ \"foo\": 1 }");
+
+            // Act
+            var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, null, int.MaxValue);
+
+            // Assert
+            //actual.
+            count.ShouldBe()
+        }
+
+        [Fact]
+        public void ReadLogEvents()
+        {
+            
+        }
+
+        [Fact]
+        public void NotReadEventGivenPartiallyWritten()
+        {
+            
+        }
+
+        [Fact]
+        public void NotReadEventsGivenPartiallyWritten()
+        {
+            
+        }
+    }
+}

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Network/PayloadReaderShould.cs
@@ -18,11 +18,8 @@ namespace Serilog.Sinks.Http.Private.Network
         public void ReadLogEvent()
         {
             // Arrange
-            var expected = new[] { Foo };
-
-            var fileContent =
-                " " +   // Adapt to offset 1
-                expected[0] + Environment.NewLine;
+            // The initial space is there to adapt to offset 1
+            var fileContent = $" {Foo}{Environment.NewLine}";
 
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
 
@@ -30,7 +27,7 @@ namespace Serilog.Sinks.Http.Private.Network
             var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
 
             // Assert
-            actual.ShouldBe(expected);
+            actual.ShouldBe(new[] { Foo });
             nextLineBeginsAtOffset.ShouldBe(fileContent.Length);
             count.ShouldBe(1);
         }
@@ -39,11 +36,9 @@ namespace Serilog.Sinks.Http.Private.Network
         public void NotReadLogEventGivenPartiallyWritten()
         {
             // Arrange
-            var expected = new string[0];
-
-            var fileContent =
-                " " +   // Adapt to offset 1
-                Foo;    // Partially written log event since new line is missing
+            // The initial space is there to adapt to offset 1, and the partially written log event
+            // is missing new line
+            var fileContent = $" {Foo}";   
 
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
 
@@ -51,8 +46,8 @@ namespace Serilog.Sinks.Http.Private.Network
             var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
 
             // Assert
-            actual.ShouldBe(expected);
-            nextLineBeginsAtOffset.ShouldBe(1);
+            actual.ShouldBeEmpty();
+            nextLineBeginsAtOffset.ShouldBe(fileContent.IndexOf(Foo, StringComparison.InvariantCulture));
             count.ShouldBe(0);
         }
 
@@ -60,12 +55,10 @@ namespace Serilog.Sinks.Http.Private.Network
         public void ReadLogEvents()
         {
             // Arrange
-            var expected = new[] { Foo, Bar };
-
+            // The initial space is there to adapt to offset 1
             var fileContent =
-                " " +   // Adapt to offset 1
-                expected[0] + Environment.NewLine +
-                expected[1] + Environment.NewLine;
+                $" {Foo}{Environment.NewLine}" +
+                $"{Bar}{Environment.NewLine}";
 
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
 
@@ -73,7 +66,7 @@ namespace Serilog.Sinks.Http.Private.Network
             var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
 
             // Assert
-            actual.ShouldBe(expected);
+            actual.ShouldBe(new[] { Foo, Bar });
             nextLineBeginsAtOffset.ShouldBe(fileContent.Length);
             count.ShouldBe(2);
         }
@@ -82,12 +75,11 @@ namespace Serilog.Sinks.Http.Private.Network
         public void NotReadEventsGivenPartiallyWritten()
         {
             // Arrange
-            var expected = new[] { Foo };
-
+            // The initial space is there to adapt to offset 1, and the partially written log event
+            // is missing new line
             var fileContent =
-                " " +           // Adapt to offset 1
-                expected[0] + Environment.NewLine +
-                Bar;    // Partially written log event since new line is missing
+                $" {Foo}{Environment.NewLine}" +
+                $"{Bar}";
 
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(fileContent));
 
@@ -95,7 +87,7 @@ namespace Serilog.Sinks.Http.Private.Network
             var actual = PayloadReader.Read(stream, ref nextLineBeginsAtOffset, ref count, int.MaxValue);
 
             // Assert
-            actual.ShouldBe(expected);
+            actual.ShouldBe(new [] { Foo });
             nextLineBeginsAtOffset.ShouldBe(fileContent.IndexOf(Bar, StringComparison.InvariantCulture));
             count.ShouldBe(1);
         }


### PR DESCRIPTION
Given many log events and potentially a slow disk, there is a chance that the sink is reading a partially written log event from disk. The partially written event will be sent over the network, and on the receiving side one will find out that the payload no longer is valid JSON.

To cope with this issue, I've changed the behavior of the reader to only accept log events lines that are terminated using a new line. Log events without a new line will be considered partially written, but will eventually be sent when when completely flushed to disk.

Closes #54 