### PR TITLE
Refactor NuGet symbol package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _ReSharper*/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,22 +10,25 @@ build_script:
 test: off
 
 artifacts:
-  - path: artifacts/Serilog.*.nupkg
+  - path: artifacts/Serilog.*.*nupkg
     name: NuGet
+    type: NuGetPackage
 
 deploy:
   - provider: GitHub
+    tag: ${APPVEYOR_REPO_TAG_NAME}
     release: Release ${APPVEYOR_REPO_TAG_NAME}
     description: TODO
     auth_token:
       secure: de2wnJZf6k7NY0XriDpf9BkrQ4MR5ZfDDWMM+H/K4OK3w0GpuJAMRj5PrO6tKu0K
-    artifact: /.*\.nupkg/
+    artifact: NuGet
     draft: true
     on:
       APPVEYOR_REPO_TAG: true
   - provider: NuGet
     api_key:
       secure: 0T2fKXtV1YG6CvJL424YGEwRzbxNPKHW7ZZA6arI1RoCW7gW3REgKx1ddPpDopaL
+    symbol_server: https://www.nuget.org
     skip_symbols: false
     on:
       APPVEYOR_REPO_TAG: true

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -29,12 +29,12 @@ foreach ($source in Get-ChildItem .\src\*)
     if ($tagged_build)
     {
         & dotnet build -c Release
-        & dotnet pack -c Release --include-symbols -o ..\..\artifacts --no-build
+        & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
     else
     {
         & dotnet build -c Release --version-suffix=$git_sha
-        & dotnet pack -c Release --include-symbols -o ..\..\artifacts --version-suffix=$git_sha --no-build
+        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$git_sha --no-build
     }
 
     if ($LASTEXITCODE -ne 0)

--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -18,7 +18,8 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>For release notes, please see the change log on GitHub.</PackageReleaseNotes>
     <!-- Embed symbols in NuGet package -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- SourceLink -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/FantasticFiasco/serilog-sinks-http.git</RepositoryUrl>


### PR DESCRIPTION
Update the build script to create a NuGet symbol package with the new `snupkg` format described in [Creating symbol packages (.snupkg)](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg).

The symbols will from now on be pushed to NuGet instead of https://nuget.smbsrc.net, since we lately have had some problems with latter.