### PR TITLE
Configuration of HTTP client when using Serilog.Settings.Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :zap: Added
+
+-  [#49](https://github.com/FantasticFiasco/serilog-sinks-http/issues/49), [#123](https://github.com/FantasticFiasco/serilog-sinks-http/issues/123) [BREAKING CHANGE] Improve support for configuring HTTP client when using [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration). See [Custom HTTP client in wiki](https://github.com/FantasticFiasco/serilog-sinks-http/wiki/Custom-HTTP-client) for more information. (discovered by [@brunorsantos](https://github.com/brunorsantos))
+
 ## [6.0.0] - 2020-05-13
 
 ### :zap: Added

--- a/src/Serilog.Sinks.Http/Extensions/Microsoft/Extensions/Configuration/IConfiguration.cs
+++ b/src/Serilog.Sinks.Http/Extensions/Microsoft/Extensions/Configuration/IConfiguration.cs
@@ -1,0 +1,23 @@
+﻿#if !NETSTANDARD_2_0
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Represents a set of key/value application configuration properties.
+    /// </summary>
+    /// <remarks>
+    /// Polyfill for
+    /// <see href="https://docs.microsoft.com/dotnet/api/microsoft.extensions.configuration.iconfiguration">
+    /// Microsoft.Extensions.Configuration.IConfiguration</see>.
+    /// </remarks>
+    public interface IConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a configuration value.
+        /// </summary>
+        /// <param name="key">The configuration key.</param>
+        /// <returns>The configuration value.</returns>
+        string this[string key] { get; set; }
+    }
+}
+#endif

--- a/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
@@ -15,6 +15,7 @@
 using System;
 using System.ComponentModel;
 using System.Net.Http;
+using Microsoft.Extensions.Configuration;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -64,6 +65,12 @@ namespace Serilog
         /// A custom <see cref="IHttpClient"/> implementation. Default value is
         /// <see cref="HttpClient"/>.
         /// </param>
+        /// <param name="configuration">
+        /// Configuration passed to <paramref name="httpClient"/>. Parameter is either manually
+        /// specified when configuring the sink in source code or automatically passed in when
+        /// configuring the sink using
+        /// <see href="https://www.nuget.org/packages/Serilog.Settings.Configuration">Serilog.Settings.Configuration</see>.
+        /// </param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public static LoggerConfiguration Http(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -74,7 +81,8 @@ namespace Serilog
             ITextFormatter textFormatter = null,
             IBatchFormatter batchFormatter = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IHttpClient httpClient = null)
+            IHttpClient httpClient = null,
+            IConfiguration configuration = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
@@ -83,6 +91,7 @@ namespace Serilog
             textFormatter = textFormatter ?? new NormalRenderedTextFormatter();
             batchFormatter = batchFormatter ?? new DefaultBatchFormatter();
             httpClient = httpClient ?? new DefaultHttpClient();
+            httpClient.Configure(configuration);
 
             var sink = queueLimit != null
                 ? new HttpSink(requestUri, batchPostingLimit, queueLimit.Value, period.Value, textFormatter, batchFormatter, httpClient)
@@ -105,7 +114,8 @@ namespace Serilog
             ITextFormatter textFormatter = null,
             IBatchFormatter batchFormatter = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IHttpClient httpClient = null)
+            IHttpClient httpClient = null,
+            IConfiguration configuration = null)
         {
             return DurableHttpUsingTimeRolledBuffers(
                 sinkConfiguration: sinkConfiguration,
@@ -119,7 +129,8 @@ namespace Serilog
                 textFormatter: textFormatter,
                 batchFormatter: batchFormatter,
                 restrictedToMinimumLevel: restrictedToMinimumLevel,
-                httpClient: httpClient);
+                httpClient: httpClient,
+                configuration: configuration);
         }
 
         /// <summary>
@@ -175,6 +186,12 @@ namespace Serilog
         /// A custom <see cref="IHttpClient"/> implementation. Default value is
         /// <see cref="HttpClient"/>.
         /// </param>
+        /// <param name="configuration">
+        /// Configuration passed to <paramref name="httpClient"/>. Parameter is either manually
+        /// specified when configuring the sink in source code or automatically passed in when
+        /// configuring the sink using
+        /// <see href="https://www.nuget.org/packages/Serilog.Settings.Configuration">Serilog.Settings.Configuration</see>.
+        /// </param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public static LoggerConfiguration DurableHttpUsingTimeRolledBuffers(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -188,7 +205,8 @@ namespace Serilog
             ITextFormatter textFormatter = null,
             IBatchFormatter batchFormatter = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IHttpClient httpClient = null)
+            IHttpClient httpClient = null,
+            IConfiguration configuration = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
@@ -197,6 +215,7 @@ namespace Serilog
             textFormatter = textFormatter ?? new NormalRenderedTextFormatter();
             batchFormatter = batchFormatter ?? new DefaultBatchFormatter();
             httpClient = httpClient ?? new DefaultHttpClient();
+            httpClient.Configure(configuration);
 
             var sink = new TimeRolledDurableHttpSink(
                 requestUri: requestUri,
@@ -268,6 +287,12 @@ namespace Serilog
         /// A custom <see cref="IHttpClient"/> implementation. Default value is
         /// <see cref="HttpClient"/>.
         /// </param>
+        /// <param name="configuration">
+        /// Configuration passed to <paramref name="httpClient"/>. Parameter is either manually
+        /// specified when configuring the sink in source code or automatically passed in when
+        /// configuring the sink using
+        /// <see href="https://www.nuget.org/packages/Serilog.Settings.Configuration">Serilog.Settings.Configuration</see>.
+        /// </param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         public static LoggerConfiguration DurableHttpUsingFileSizeRolledBuffers(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -281,7 +306,8 @@ namespace Serilog
             ITextFormatter textFormatter = null,
             IBatchFormatter batchFormatter = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IHttpClient httpClient = null)
+            IHttpClient httpClient = null,
+            IConfiguration configuration = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
@@ -290,6 +316,7 @@ namespace Serilog
             textFormatter = textFormatter ?? new NormalRenderedTextFormatter();
             batchFormatter = batchFormatter ?? new DefaultBatchFormatter();
             httpClient = httpClient ?? new DefaultHttpClient();
+            httpClient.Configure(configuration);
 
             var sink = new FileSizeRolledDurableHttpSink(
                 requestUri: requestUri,

--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- GENERAL -->
+
   <PropertyGroup>
     <AssemblyName>Serilog.Sinks.Http</AssemblyName>
     <Description>A Serilog sink sending log events over HTTP.</Description>
@@ -30,8 +32,14 @@
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <!-- SourceLink -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="assets\serilog-sink-nuget.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <!-- .NET FRAMEWORK -->
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
     <Reference Include="System" />
@@ -43,8 +51,14 @@
     <DefineConstants>$(DefineConstants);HRESULTS</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="assets\serilog-sink-nuget.png" Pack="true" PackagePath="\"/>
+  <!-- .NET STANDARD -->
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD_2_0</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Http/Sinks/Http/IHttpClient.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/IHttpClient.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Serilog.Sinks.Http
 {
@@ -23,6 +24,12 @@ namespace Serilog.Sinks.Http
     /// </summary>
     public interface IHttpClient : IDisposable
     {
+        /// <summary>
+        /// Configures the HTTP client.
+        /// </summary>
+        /// <param name="configuration">The application configuration properties.</param>
+        void Configure(IConfiguration configuration);
+
         /// <summary>
         /// Sends a POST request to the specified Uri as an asynchronous operation.
         /// </summary>

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DefaultHttpClient.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Network/DefaultHttpClient.cs
@@ -14,6 +14,7 @@
 
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Serilog.Sinks.Http.Private.Network
 {
@@ -23,6 +24,11 @@ namespace Serilog.Sinks.Http.Private.Network
 
         public DefaultHttpClient() =>
             httpClient = new HttpClient();
+
+        public void Configure(IConfiguration configuration)
+        {
+            // The default HTTP client requires no configuration
+        }
 
         public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content) =>
             httpClient.PostAsync(requestUri, content);

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkGivenAppSettingsShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkGivenAppSettingsShould.cs
@@ -16,8 +16,12 @@ namespace Serilog
             Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkGivenCodeConfigurationShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkGivenCodeConfigurationShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Sinks.Http.BatchFormatters;
 using Serilog.Sinks.Http.TextFormatters;
@@ -11,6 +12,8 @@ namespace Serilog
         public DurableHttpSinkGivenCodeConfigurationShould()
         {
             DeleteBufferFiles();
+            
+            var configuration = new ConfigurationBuilder().Build();
 
 #pragma warning disable CS0618 // Type or member is obsolete
 
@@ -23,12 +26,17 @@ namespace Serilog
                     period: TimeSpan.FromMilliseconds(1),
                     textFormatter: new NormalRenderedTextFormatter(),
                     batchFormatter: new DefaultBatchFormatter(),
-                    httpClient: new HttpClientMock())
+                    httpClient: new HttpClientMock(),
+                    configuration: configuration)
                 .CreateLogger();
 
 #pragma warning restore CS0618 // Type or member is obsolete
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingFileSizeRolledBuffersGivenAppSettingsShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingFileSizeRolledBuffersGivenAppSettingsShould.cs
@@ -16,8 +16,12 @@ namespace Serilog
             Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingFileSizeRolledBuffersGivenCodeConfigurationShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingFileSizeRolledBuffersGivenCodeConfigurationShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Sinks.Http.BatchFormatters;
 using Serilog.Sinks.Http.TextFormatters;
@@ -12,6 +13,8 @@ namespace Serilog
         {
             DeleteBufferFiles();
 
+            var configuration = new ConfigurationBuilder().Build();
+
             Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo
@@ -21,10 +24,15 @@ namespace Serilog
                     period: TimeSpan.FromMilliseconds(1),
                     textFormatter: new NormalRenderedTextFormatter(),
                     batchFormatter: new DefaultBatchFormatter(),
-                    httpClient: new HttpClientMock())
+                    httpClient: new HttpClientMock(),
+                    configuration: configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingTimeRolledBuffersGivenAppSettingsShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingTimeRolledBuffersGivenAppSettingsShould.cs
@@ -16,8 +16,12 @@ namespace Serilog
             Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingTimeRolledBuffersGivenCodeConfigurationShould.cs
+++ b/test/Serilog.Sinks.HttpTests/DurableHttpSinkUsingTimeRolledBuffersGivenCodeConfigurationShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Sinks.Http.BatchFormatters;
 using Serilog.Sinks.Http.TextFormatters;
@@ -12,6 +13,8 @@ namespace Serilog
         {
             DeleteBufferFiles();
 
+            var configuration = new ConfigurationBuilder().Build();
+
             Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo
@@ -21,10 +24,15 @@ namespace Serilog
                     period: TimeSpan.FromMilliseconds(1),
                     textFormatter: new NormalRenderedTextFormatter(),
                     batchFormatter: new DefaultBatchFormatter(),
-                    httpClient: new HttpClientMock())
+                    httpClient: new HttpClientMock(),
+                    configuration: configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/HttpSinkGivenAppSettingsShould.cs
+++ b/test/Serilog.Sinks.HttpTests/HttpSinkGivenAppSettingsShould.cs
@@ -14,8 +14,12 @@ namespace Serilog
             Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
                 .CreateLogger();
+
+            Configuration = configuration;
         }
 
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/HttpSinkGivenCodeConfigurationShould.cs
+++ b/test/Serilog.Sinks.HttpTests/HttpSinkGivenCodeConfigurationShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Sinks.Http.BatchFormatters;
 using Serilog.Sinks.Http.TextFormatters;
@@ -8,7 +9,10 @@ namespace Serilog
 {
     public class HttpSinkGivenCodeConfigurationShould : SinkFixture
     {
-        public HttpSinkGivenCodeConfigurationShould() =>
+        public HttpSinkGivenCodeConfigurationShould()
+        {
+            var configuration = new ConfigurationBuilder().Build();
+
             Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo
@@ -19,9 +23,15 @@ namespace Serilog
                     period: TimeSpan.FromMilliseconds(1),
                     textFormatter: new NormalRenderedTextFormatter(),
                     batchFormatter: new DefaultBatchFormatter(),
-                    httpClient: new HttpClientMock())
+                    httpClient: new HttpClientMock(),
+                    configuration: configuration)
                 .CreateLogger();
 
+            Configuration = configuration;
+        }
+
         protected override Logger Logger { get; }
+
+        protected override IConfiguration Configuration { get; }
     }
 }

--- a/test/Serilog.Sinks.HttpTests/SinkFixture.cs
+++ b/test/Serilog.Sinks.HttpTests/SinkFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Support;
@@ -13,6 +14,14 @@ namespace Serilog
     public abstract class SinkFixture : IDisposable
     {
         protected abstract Logger Logger { get; }
+        protected abstract IConfiguration Configuration { get; }
+
+        [Fact]
+        public void ConfigureHttpClient()
+        {
+            // Assert
+            HttpClientMock.Instance.Configuration.ShouldBe(Configuration);
+        }
 
         [Theory]
         [InlineData(LogEventLevel.Verbose)]

--- a/test/Serilog.Sinks.HttpTests/Support/HttpClientMock.cs
+++ b/test/Serilog.Sinks.HttpTests/Support/HttpClientMock.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Serilog.Sinks.Http;
 using Serilog.Sinks.Http.BatchFormatters;
@@ -37,6 +38,8 @@ namespace Serilog.Support
                 .Select(logEvent => logEvent.RenderedMessage)
                 .ToArray();
 
+        public IConfiguration Configuration { get; private set; }
+
         public async Task WaitAsync(int expectedLogEventCount)
         {
             // 10 000 iterations, each waiting at least 1ms, means that a test has 10s to pass
@@ -58,6 +61,9 @@ namespace Serilog.Support
 
         public void SimulateNetworkFailure() =>
             simulateNetworkFailure = true;
+
+
+        public void Configure(IConfiguration configuration) => Configuration = configuration;
 
         public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
         {


### PR DESCRIPTION
Improve support to configure HTTP client when using [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration)

Closes #49
Closes #123