### PR TITLE
Shim Microsoft.Extensions.Configuration.IConfiguration for net45 and netstandard1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 - Add class `ByteSize` which helps specifying multipliers of the unit *byte*.
 
+### :syringe: Fixed
+
+- [#135](https://github.com/FantasticFiasco/serilog-sinks-http/issues/135) The type `IConfiguration` exists in both `Microsoft.Extensions.Configuration.Abstractions` and `Serilog.Sinks.Http` (discovered by [@brian-pickens-web](https://github.com/brian-pickens-web) and contributed by [@aleksaradz](https://github.com/aleksaradz))
+
 ## [7.0.1] - 2020-08-14
 
 ### :syringe: Fixed

--- a/src/Serilog.Sinks.Http/Extensions/Microsoft/Extensions/Configuration/IConfiguration.cs
+++ b/src/Serilog.Sinks.Http/Extensions/Microsoft/Extensions/Configuration/IConfiguration.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !NETSTANDARD_2_0
+#if NET45 || NETSTANDARD_1_3
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Configuration
 {

--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -58,13 +58,21 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
     <DefineConstants>$(DefineConstants);HRESULTS</DefineConstants>
   </PropertyGroup>
 
   <!-- .NET STANDARD -->
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD_1_3</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net45' And '$(TargetFramework)' != 'netstandard1.3'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
   </ItemGroup>
 


### PR DESCRIPTION
This pullrequest is for fixing the issue #135

The shim of `Microsoft.Extensions.Configuration.IConfiguration` was being added for any target that is not `netstandard2.0` and now it's applied only for the targets that need it: `net45` and `netstandard1.3`
