### PR TITLE
Add netstandard2.1 target & update test project to netcoreapp31

### DIFF
--- a/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
+++ b/src/Serilog.Sinks.Http/Serilog.Sinks.Http.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyName>Serilog.Sinks.Http</AssemblyName>
     <Description>A Serilog sink sending log events over HTTP.</Description>
-    <TargetFrameworks>net45;net461;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard1.3;netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Serilog</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Strong naming -->
@@ -78,6 +78,10 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD_2_0</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD_2_1</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/test/Serilog.Sinks.HttpTests/Serilog.Sinks.HttpTests.csproj
+++ b/test/Serilog.Sinks.HttpTests/Serilog.Sinks.HttpTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Serilog</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Add `netstandard2.1` target to `Serilog.Sinks.Http` project
- Update `Serilog.Sinks.HttpTests` to target `netcoreapp3.1`

---

Closes #140