### PR TITLE
Buffer files without BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 - [#116](https://github.com/FantasticFiasco/serilog-sinks-http/issues/116) [BREAKING CHANGE] Support specifying `batchSizeLimitBytes` when creating the sink, thus limiting the size of the payloads sent to the log server (proposed by [@michaeltdaniels](https://github.com/michaeltdaniels))
 
+### :dizzy: Changed
+
+- Durable buffer files are no longer created with an initial [BOM](https://en.wikipedia.org/wiki/Byte_order_mark)
+
 ## [7.2.0] - 2020-10-19
 
 ### :zap: Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 - [#116](https://github.com/FantasticFiasco/serilog-sinks-http/issues/116) [BREAKING CHANGE] Support specifying `batchSizeLimitBytes` when creating the sink, thus limiting the size of the payloads sent to the log server (proposed by [@michaeltdaniels](https://github.com/michaeltdaniels))
 
-### :dizzy: Changed
+### :syringe: Fixed
 
 - Durable buffer files are no longer created with an initial [BOM](https://en.wikipedia.org/wiki/Byte_order_mark)
 

--- a/serilog-sinks-http.sln.DotSettings
+++ b/serilog-sinks-http.sln.DotSettings
@@ -122,6 +122,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LF/@EntryIndexedValue">LF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UTF/@EntryIndexedValue">UTF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BookmarkFile.cs
@@ -20,6 +20,8 @@ namespace Serilog.Sinks.Http.Private.Durable
 {
     public class BookmarkFile : IDisposable
     {
+        private static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         private readonly FileStream fileStream;
 
         public BookmarkFile(string bookmarkFileName)
@@ -41,7 +43,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             if (fileStream.Length != 0)
             {
                 // Important not to dispose this StreamReader as the stream must remain open
-                var reader = new StreamReader(fileStream, Encoding.UTF8, false, 128);
+                var reader = new StreamReader(fileStream, Encoding, false, 128);
                 var bookmark = reader.ReadLine();
 
                 if (bookmark != null)
@@ -62,7 +64,7 @@ namespace Serilog.Sinks.Http.Private.Durable
 
         public void WriteBookmark(long nextLineBeginsAtOffset, string currentFile)
         {
-            using var writer = new StreamWriter(fileStream);
+            using var writer = new StreamWriter(fileStream, Encoding);
             writer.WriteLine("{0}:::{1}", nextLineBeginsAtOffset, currentFile);
         }
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BufferFileReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BufferFileReader.cs
@@ -20,16 +20,13 @@ namespace Serilog.Sinks.Http.Private.Durable
 {
     public static class BufferFileReader
     {
+        public static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         private const char CR = '\r';
         private const char LF = '\n';
 
         private static readonly string CRLFString = $"{CR}{LF}";
         private static readonly string LFString = $"{LF}";
-
-        /// <summary>
-        /// The length of the Byte Order Marks (BOM).
-        /// </summary>
-        public const int BomLength = 3;
 
         public static Batch Read(
             string fileName,
@@ -89,8 +86,7 @@ namespace Serilog.Sinks.Http.Private.Durable
                 }
 
                 // Update cursor
-                var bomLength = nextLineBeginsAtOffset == 0 ? BomLength : 0;
-                nextLineBeginsAtOffset += bomLength + lineSizeBytes + ByteSize.From(line.NewLine);
+                nextLineBeginsAtOffset += lineSizeBytes + ByteSize.From(line.NewLine);
 
                 // Add log event
                 if (includeLine)
@@ -119,7 +115,7 @@ namespace Serilog.Sinks.Http.Private.Durable
         private static Line ReadLine(Stream stream)
         {
             // Important not to dispose this StreamReader as the stream must remain open
-            var reader = new StreamReader(stream, Encoding.UTF8, false, 128);
+            var reader = new StreamReader(stream, Encoding, false, 128);
             var lineBuilder = new StringBuilder();
 
             while (true)

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
@@ -64,14 +64,13 @@ namespace Serilog.Sinks.Http.Private.Durable
 
             sink = new LoggerConfiguration()
                 .WriteTo.File(
-                    textFormatter,
-                    $"{bufferBaseFileName}-.json",
+                    formatter: textFormatter,
+                    path: $"{bufferBaseFileName}-.json",
                     fileSizeLimitBytes: bufferFileSizeLimitBytes,
                     shared: bufferFileShared,
-                    rollOnFileSizeLimit: true,
-                    retainedFileCountLimit: retainedBufferFileCountLimit,
                     rollingInterval: RollingInterval.Day,
-                    encoding: Encoding.UTF8)
+                    rollOnFileSizeLimit: true,
+                    retainedFileCountLimit: retainedBufferFileCountLimit)
                 .CreateLogger();
         }
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Text;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -64,11 +63,10 @@ namespace Serilog.Sinks.Http.Private.Durable
                 batchFormatter);
 
             sink = new RollingFileSink(
-                bufferPathFormat,
-                textFormatter,
-                bufferFileSizeLimitBytes,
-                retainedBufferFileCountLimit,
-                Encoding.UTF8,
+                pathFormat: bufferPathFormat,
+                textFormatter: textFormatter,
+                fileSizeLimitBytes: bufferFileSizeLimitBytes,
+                retainedFileCountLimit: retainedBufferFileCountLimit,
                 shared: bufferFileShared);
         }
 

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text;
 using Shouldly;
 using Xunit;
 

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
@@ -19,7 +19,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Flush();
 
@@ -38,7 +38,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent);  // The partially written log event is missing new line
             writer.Flush();
 
@@ -77,7 +77,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent);  // The partially written log event is missing new line
             writer.Flush();
@@ -88,7 +88,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Assert
             got.LogEvents.ShouldBe(new[] { FooLogEvent });
             got.HasReachedLimit.ShouldBeFalse();
-            nextLineBeginsAtOffset.ShouldBe(BufferFileReader.BomLength + FooLogEvent.Length + Environment.NewLine.Length);
+            nextLineBeginsAtOffset.ShouldBe(FooLogEvent.Length + Environment.NewLine.Length);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -110,7 +110,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Assert
             got.LogEvents.ShouldBe(new[] { FooLogEvent });
             got.HasReachedLimit.ShouldBeTrue();
-            nextLineBeginsAtOffset.ShouldBe(BufferFileReader.BomLength + FooLogEvent.Length + Environment.NewLine.Length);
+            nextLineBeginsAtOffset.ShouldBe(FooLogEvent.Length + Environment.NewLine.Length);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -132,7 +132,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Assert
             got.LogEvents.ShouldBe(new[] { FooLogEvent });
             got.HasReachedLimit.ShouldBeTrue();
-            nextLineBeginsAtOffset.ShouldBe(BufferFileReader.BomLength + FooLogEvent.Length + Environment.NewLine.Length);
+            nextLineBeginsAtOffset.ShouldBe(FooLogEvent.Length + Environment.NewLine.Length);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Serilog.Sinks.Http.Private.Durable
 
             const string logEventExceedingBatchSizeLimit = "{ \"foo\": \"This document exceeds the batch size limit\" }";
 
-            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
             writer.Write(logEventExceedingBatchSizeLimit + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();


### PR DESCRIPTION
Let's configure the sink to create buffer files without a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark).