### PR TITLE
fix: remove BOM from HTTP streams

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -102,6 +102,16 @@
         "code",
         "ideas"
       ]
+    },
+    {
+      "login": "KalininAndreyVictorovich",
+      "name": "KalininAndreyVictorovich",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1285535?v=4",
+      "profile": "https://github.com/KalininAndreyVictorovich",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ The following users have made significant contributions to this project. Thank y
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/dusse1dorf"><img src="https://avatars.githubusercontent.com/u/37047967?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dusse1dorf</b></sub></a><br /><a href="#ideas-dusse1dorf" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="https://github.com/vaibhavepatel"><img src="https://avatars.githubusercontent.com/u/23142694?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vaibhavepatel</b></sub></a><br /><a href="#ideas-vaibhavepatel" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/vaibhavepatel"><img src="https://avatars.githubusercontent.com/u/23142694?v=4?s=100" width="100px;" alt=""/><br /><sub><b>vaibhavepatel</b></sub></a><br /><a href="https://github.com/FantasticFiasco/serilog-sinks-http/commits?author=vaibhavepatel" title="Code">💻</a> <a href="#ideas-vaibhavepatel" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/KalininAndreyVictorovich"><img src="https://avatars.githubusercontent.com/u/1285535?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KalininAndreyVictorovich</b></sub></a><br /><a href="https://github.com/FantasticFiasco/serilog-sinks-http/issues?q=author%3AKalininAndreyVictorovich" title="Bug reports">🐛</a> <a href="https://github.com/FantasticFiasco/serilog-sinks-http/commits?author=KalininAndreyVictorovich" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/ByteSize.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/ByteSize.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Text;
+using Serilog.Sinks.Http.Private;
 
 namespace Serilog.Sinks.Http
 {
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.Http
         /// <returns>The number of bytes produced by encoding the specified characters.</returns>
         public static long From(string text)
         {
-            return Encoding.UTF8.GetByteCount(text);
+            return Encoding.UTF8WithoutBom.GetByteCount(text);
         }
     }
 }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BookmarkFile.cs
@@ -14,14 +14,11 @@
 
 using System;
 using System.IO;
-using System.Text;
 
 namespace Serilog.Sinks.Http.Private.Durable
 {
     public class BookmarkFile : IDisposable
     {
-        private static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
         private readonly FileStream fileStream;
 
         public BookmarkFile(string bookmarkFileName)
@@ -43,7 +40,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             if (fileStream.Length != 0)
             {
                 // Important not to dispose this StreamReader as the stream must remain open
-                var reader = new StreamReader(fileStream, Encoding, false, 128);
+                var reader = new StreamReader(fileStream, Encoding.UTF8WithoutBom, false, 128);
                 var bookmark = reader.ReadLine();
 
                 if (bookmark != null)
@@ -64,7 +61,7 @@ namespace Serilog.Sinks.Http.Private.Durable
 
         public void WriteBookmark(long nextLineBeginsAtOffset, string currentFile)
         {
-            using var writer = new StreamWriter(fileStream, Encoding);
+            using var writer = new StreamWriter(fileStream, Encoding.UTF8WithoutBom);
             writer.WriteLine("{0}:::{1}", nextLineBeginsAtOffset, currentFile);
         }
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BufferFileReader.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/BufferFileReader.cs
@@ -20,8 +20,6 @@ namespace Serilog.Sinks.Http.Private.Durable
 {
     public static class BufferFileReader
     {
-        public static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
         private const char CR = '\r';
         private const char LF = '\n';
 
@@ -115,7 +113,7 @@ namespace Serilog.Sinks.Http.Private.Durable
         private static Line ReadLine(Stream stream)
         {
             // Important not to dispose this StreamReader as the stream must remain open
-            var reader = new StreamReader(stream, Encoding, false, 128);
+            var reader = new StreamReader(stream, Encoding.UTF8WithoutBom, false, 128);
             var lineBuilder = new StringBuilder();
 
             while (true)

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/HttpLogShipper.cs
@@ -16,7 +16,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Sinks.Http.Private.Time;
@@ -120,7 +119,7 @@ namespace Serilog.Sinks.Http.Private.Durable
                         HttpResponseMessage response;
 
                         using (var contentStream = new MemoryStream())
-                        using (var contentWriter = new StreamWriter(contentStream, Encoding.UTF8))
+                        using (var contentWriter = new StreamWriter(contentStream, Encoding.UTF8WithoutBom))
                         {
                             batchFormatter.Format(batch.LogEvents, contentWriter);
 

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Encoding.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Encoding.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2015-2021 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+namespace Serilog.Sinks.Http.Private
+{
+    public static class Encoding
+    {
+        public static readonly System.Text.Encoding UTF8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    }
+}

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
@@ -15,7 +15,6 @@
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -126,7 +125,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                         HttpResponseMessage response;
 
                         using (var contentStream = new MemoryStream())
-                        using (var contentWriter = new StreamWriter(contentStream, Encoding.UTF8))
+                        using (var contentWriter = new StreamWriter(contentStream, Encoding.UTF8WithoutBom))
                         {
                             batchFormatter.Format(batch.LogEvents, contentWriter);
 

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/BufferFileReaderShould.cs
@@ -18,7 +18,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Flush();
 
@@ -37,7 +37,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -57,7 +57,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent);  // The partially written log event is missing new line
             writer.Flush();
 
@@ -76,7 +76,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent);  // The partially written log event is missing new line
             writer.Flush();
@@ -96,7 +96,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -118,7 +118,7 @@ namespace Serilog.Sinks.Http.Private.Durable
             // Arrange
             using var stream = new MemoryStream();
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(FooLogEvent + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();
@@ -142,7 +142,7 @@ namespace Serilog.Sinks.Http.Private.Durable
 
             const string logEventExceedingBatchSizeLimit = "{ \"foo\": \"This document exceeds the batch size limit\" }";
 
-            using var writer = new StreamWriter(stream, BufferFileReader.Encoding);
+            using var writer = new StreamWriter(stream, Encoding.UTF8WithoutBom);
             writer.Write(logEventExceedingBatchSizeLimit + Environment.NewLine);
             writer.Write(BarLogEvent + Environment.NewLine);
             writer.Flush();

--- a/test/Serilog.Sinks.HttpTests/Support/HttpClientMock.cs
+++ b/test/Serilog.Sinks.HttpTests/Support/HttpClientMock.cs
@@ -86,6 +86,16 @@ namespace Serilog.Support
                 return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
             }
 
+            // Make sure content stream doesn't contain BOM
+            var head = new byte[3];
+            await contentStream.ReadAsync(head, 0, 3);
+            if (head.SequenceEqual(System.Text.Encoding.UTF8.GetPreamble()))
+            {
+                throw new XunitException("Content stream contains UTF8 BOM");
+            }
+
+            contentStream.Position = 0;
+
             DefaultBatch batch;
 
             try


### PR DESCRIPTION
# Description

Change Encoding of `StreamWriter` in durable `HttpLogShipper` and  non durable `HttpSink` from standard UTF8 to customized one with disabled BOM.

Fixes #188 

# Checklist

- [x] I have squashed my commits into a single one with a message that aligns with the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works


I'm not totally sure how I implemented tests for this...