### PR TITLE
Update JsonGzipHttpClient.cs

### DIFF
--- a/src/Serilog.Sinks.Http/Sinks/Http/HttpClients/JsonGzipHttpClient.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/HttpClients/JsonGzipHttpClient.cs
@@ -81,7 +81,8 @@ namespace Serilog.Sinks.Http.HttpClients
             await contentStream
                 .CopyToAsync(gzipStream)
                 .ConfigureAwait(false);
-
+            await gzipStream.FlushAsync();
+            
             output.Position = 0;
 
             var content = new StreamContent(output);


### PR DESCRIPTION
Add data flushing from gzipStream to underlying stream.

MSDN says: 

> The write operation might not occur immediately but is buffered until the buffer size is reached or until the Flush or Close method is called.

C# 8 `using var`  does not make it flushed automatically because it

>  tells the compiler that the variable being declared should be disposed at the **end of the enclosing scope**

# Description
Fixes https://github.com/FantasticFiasco/serilog-sinks-http/issues/190

