### PR TITLE
fix gzip http request footer by using dispose() instead of flush()

### DIFF
--- a/src/Serilog.Sinks.Http/Sinks/Http/HttpClients/JsonGzipHttpClient.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/HttpClients/JsonGzipHttpClient.cs
@@ -76,13 +76,13 @@ namespace Serilog.Sinks.Http.HttpClients
         public virtual async Task<HttpResponseMessage> PostAsync(string requestUri, Stream contentStream)
         {
             using var output = new MemoryStream();
-            using var gzipStream = new GZipStream(output, CompressionLevel);
-            
-            await contentStream
-                .CopyToAsync(gzipStream)
-                .ConfigureAwait(false);
-            await gzipStream.FlushAsync();
-            
+
+            using (var gzipStream = new GZipStream(output, CompressionLevel, true)){
+                await contentStream
+                    .CopyToAsync(gzipStream)
+                    .ConfigureAwait(false);
+            }
+
             output.Position = 0;
 
             var content = new StreamContent(output);


### PR DESCRIPTION
# Description
Changing flush() to dispose()
It turns out that flush() and dispose() methods are not equivalent for GZipStream.

Related issues at dotnet runtime:
https://github.com/dotnet/runtime/issues/52532
https://github.com/dotnet/runtime/issues/15371

Fixes https://github.com/FantasticFiasco/serilog-sinks-http/issues/193

