### PR TITLE
Queue limit in non-durable sink should be defined in byte size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,59 @@ Given you are configuring the sink in application configuration you should do th
 ```
 
 - [#206](https://github.com/FantasticFiasco/serilog-sinks-http/issues/206) [BREAKING CHANGE] Argument `bufferFileSizeLimitBytes` to extension methods `DurableHttpUsingFileSizeRolledBuffers` and `DurableHttpUsingTimeRolledBuffers` no longer accepts `0` as value
+- [#203](https://github.com/FantasticFiasco/serilog-sinks-http/issues/203) [BREAKING CHANGE] Non-durable sink has changed from having its maximum queue size defined as number of events into number of bytes, making it far easier to reason about memory consumption.
+
+Given you are configuring the sink in code you should do the following changes.
+
+```csharp
+// Before migration
+log = new LoggerConfiguration()
+  .WriteTo.Http(
+    requestUri: "https://www.mylogs.com",
+    queueLimit: 1000)
+  .CreateLogger();
+
+// After migration
+log = new LoggerConfiguration()
+  .WriteTo.Http(
+    requestUri: "https://www.mylogs.com",
+    queueLimitBytes: 50 * ByteSize.MB)
+  .CreateLogger();
+```
+
+Given you are configuring the sink in application configuration you should do the following changes.
+
+```json
+// Before migration
+{
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Http",
+        "Args": {
+          "requestUri": "https://www.mylogs.com",
+          "queueLimit": 1000
+        }
+      }
+    ]
+  }
+}
+
+// After migration
+{
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Http",
+        "Args": {
+          "requestUri": "https://www.mylogs.com",
+          "queueLimitBytes": 52428800
+        }
+      }
+    ]
+  }
+}
+```
 
 ### :skull: Removed
 

--- a/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
@@ -48,7 +48,7 @@ namespace Serilog
         /// exceeding this size will be dropped. Specify null for no limit. Default value is null.
         /// </param>
         /// <param name="logEventsInBatchLimit">
-        /// The maximum number of log events posted as a single batch over the network. Default
+        /// The maximum number of log events sent as a single batch over the network. Default
         /// value is 1000.
         /// </param>
         /// <param name="batchSizeLimitBytes">
@@ -67,9 +67,9 @@ namespace Serilog
         /// <para/>
         /// Default value is null.
         /// </param>
-        /// <param name="queueLimit">
-        /// The maximum number of events stored in the queue in memory, waiting to be posted over
-        /// the network. Default value is infinitely.
+        /// <param name="queueLimitBytes">
+        /// The maximum size, in bytes, of events stored in memory, waiting to be sent over the
+        /// network. Specify null for no limit. Default value is null.
         /// </param>
         /// <param name="period">
         /// The time to wait between checking for event batches. Default value is 2 seconds.
@@ -103,7 +103,7 @@ namespace Serilog
             long? logEventLimitBytes = null,
             int? logEventsInBatchLimit = 1000,
             long? batchSizeLimitBytes = null,
-            int? queueLimit = null,
+            long? queueLimitBytes = null,
             TimeSpan? period = null,
             ITextFormatter? textFormatter = null,
             IBatchFormatter? batchFormatter = null,
@@ -130,7 +130,7 @@ namespace Serilog
                 logEventLimitBytes: logEventLimitBytes,
                 logEventsInBatchLimit: logEventsInBatchLimit,
                 batchSizeLimitBytes: batchSizeLimitBytes,
-                queueLimit: queueLimit,
+                queueLimitBytes: queueLimitBytes,
                 period: period.Value,
                 textFormatter: textFormatter,
                 batchFormatter: batchFormatter,
@@ -180,7 +180,7 @@ namespace Serilog
         /// exceeding this size will be dropped. Specify null for no limit. Default value is null.
         /// </param>
         /// <param name="logEventsInBatchLimit">
-        /// The maximum number of log events posted as a single batch over the network. Default
+        /// The maximum number of log events sent as a single batch over the network. Default
         /// value is 1000.
         /// </param>
         /// <param name="batchSizeLimitBytes">
@@ -314,7 +314,7 @@ namespace Serilog
         /// exceeding this size will be dropped. Specify null for no limit. Default value is null.
         /// </param>
         /// <param name="logEventsInBatchLimit">
-        /// The maximum number of log events posted as a single batch over the network. Default
+        /// The maximum number of log events sent as a single batch over the network. Default
         /// value is 1000.
         /// </param>
         /// <param name="batchSizeLimitBytes">

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
             long? logEventLimitBytes,
             int? logEventsInBatchLimit,
             long? batchSizeLimitBytes,
-            int? queueLimit,
+            long? queueLimitBytes,
             TimeSpan period,
             ITextFormatter textFormatter,
             IBatchFormatter batchFormatter,
@@ -62,7 +62,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
 
             connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
             timer = new PortableTimer(OnTick);
-            queue = new LogEventQueue(queueLimit);
+            queue = new LogEventQueue(queueLimitBytes);
 
             SetTimer();
         }

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/LogEventQueue.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/LogEventQueue.cs
@@ -20,16 +20,16 @@ namespace Serilog.Sinks.Http.Private.NonDurable
     public class LogEventQueue
     {
         private readonly Queue<string> queue;
-        private readonly int? queueLimit;
+        private readonly long? queueLimitBytes;
         private readonly object syncRoot = new();
 
-        public LogEventQueue(int? queueLimit = null)
+        public LogEventQueue(long? queueLimitBytes = null)
         {
-            if (queueLimit < 1)
-                throw new ArgumentException("queueLimit must be either null or greater than 0", nameof(queueLimit));
+            if (queueLimitBytes < 1)
+                throw new ArgumentException("queueLimitBytes must be either null or greater than 0", nameof(queueLimitBytes));
 
             queue = new Queue<string>();
-            this.queueLimit = queueLimit;
+            this.queueLimitBytes = queueLimitBytes;
         }
 
         public void Enqueue(string logEvent)

--- a/test/Serilog.Sinks.HttpTests/HttpSinkGivenCodeConfigurationShould.cs
+++ b/test/Serilog.Sinks.HttpTests/HttpSinkGivenCodeConfigurationShould.cs
@@ -21,7 +21,7 @@ namespace Serilog
                     requestUri: "https://www.mylogs.com",
                     logEventsInBatchLimit: 100,
                     batchSizeLimitBytes: ByteSize.MB,
-                    queueLimit: 10000,
+                    queueLimitBytes: ByteSize.MB,
                     period: TimeSpan.FromMilliseconds(1),
                     textFormatter: new NormalRenderedTextFormatter(),
                     batchFormatter: new DefaultBatchFormatter(),

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
@@ -76,15 +76,13 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                 .Select(number => Some.LogEvent("Event {number}", number))
                 .ToArray();
 
-            
-            // TODO: Calculate the size of the first log event, and set the value as queueLimitBytes
             using var sink = new HttpSink(
                 requestUri: "https://www.mylogs.com",
                 logEventLimitBytes: null,
                 logEventsInBatchLimit: null,
                 batchSizeLimitBytes: null,
-                queueLimitBytes: 1, // Queue only holds the first event
-                period: TimeSpan.FromMilliseconds(1), // 1 ms period
+                queueLimitBytes: 134, // Queue only holds the first event, which allocates 134 bytes
+                period: TimeSpan.FromMilliseconds(10), // 10 ms period
                 textFormatter: new NormalTextFormatter(),
                 batchFormatter: new DefaultBatchFormatter(),
                 httpClient: httpClient);
@@ -95,9 +93,10 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                 sink.Emit(logEvent);
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(10)); // Sleep 10000x the period
+            await Task.Delay(TimeSpan.FromSeconds(10)); // Sleep 1000x the period
 
             // Assert
+            httpClient.LogEvents.Length.ShouldBeGreaterThan(0);
             httpClient.LogEvents.Length.ShouldBeLessThan(logEvents.Length); // Some log events will have been dropped
         }
     }

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                 logEventLimitBytes: null,
                 logEventsInBatchLimit: null,
                 batchSizeLimitBytes: null,
-                queueLimit: null,
+                queueLimitBytes: null,
                 period: TimeSpan.FromMilliseconds(1), // 1 ms period
                 textFormatter: new NormalTextFormatter(),
                 batchFormatter: new DefaultBatchFormatter(),
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                 logEventLimitBytes: 1, // Is lower than emitted log event
                 logEventsInBatchLimit: null,
                 batchSizeLimitBytes: null,
-                queueLimit: null,
+                queueLimitBytes: null,
                 period: TimeSpan.FromMilliseconds(1), // 1 ms period
                 textFormatter: new NormalTextFormatter(),
                 batchFormatter: new DefaultBatchFormatter(),
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
         }
 
         [Fact]
-        public async Task RespectQueueLimit()
+        public async Task RespectQueueLimitBytes()
         {
             // Arrange
             var httpClient = new HttpClientMock();
@@ -76,12 +76,14 @@ namespace Serilog.Sinks.Http.Private.NonDurable
                 .Select(number => Some.LogEvent("Event {number}", number))
                 .ToArray();
 
+            
+            // TODO: Calculate the size of the first log event, and set the value as queueLimitBytes
             using var sink = new HttpSink(
                 requestUri: "https://www.mylogs.com",
                 logEventLimitBytes: null,
                 logEventsInBatchLimit: null,
                 batchSizeLimitBytes: null,
-                queueLimit: 1, // Queue only holds 1 event
+                queueLimitBytes: 1, // Queue only holds the first event
                 period: TimeSpan.FromMilliseconds(1), // 1 ms period
                 textFormatter: new NormalTextFormatter(),
                 batchFormatter: new DefaultBatchFormatter(),

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/LogEventQueueShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/LogEventQueueShould.cs
@@ -6,6 +6,20 @@ namespace Serilog.Sinks.Http.Private.NonDurable
 {
     public class LogEventQueueShould
     {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(long.MinValue)]
+        public void ThrowExceptionGivenInvalidQueueLimitBytes(long queueLimitBytes)
+        {
+            // Arrange
+            // ReSharper disable once ObjectCreationAsStatement
+            var got = new Action(() => new LogEventQueue(queueLimitBytes));
+
+            // Assert
+            got.ShouldThrow<ArgumentException>();
+        }
+
         [Fact]
         public void UseFifo()
         {

--- a/test/Serilog.Sinks.HttpTests/appsettings_http.json
+++ b/test/Serilog.Sinks.HttpTests/appsettings_http.json
@@ -8,7 +8,7 @@
           "requestUri": "https://www.mylogs.com",
           "logEventsInBatchLimit": 100,
           "batchSizeLimitBytes": 1048576,
-          "queueLimit": 10000,
+          "queueLimitBytes": 1048576,
           "period": "00:00:00.001",
           "textFormatter": "Serilog.Sinks.Http.TextFormatters.NormalRenderedTextFormatter, Serilog.Sinks.Http",
           "batchFormatter": "Serilog.Sinks.Http.BatchFormatters.DefaultBatchFormatter, Serilog.Sinks.Http",


### PR DESCRIPTION
Fixes #203 