### PR TITLE
feat: add queue size limit configuration (#315)

### DIFF
--- a/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
@@ -48,6 +48,8 @@ namespace Serilog
         /// The maximum size, in bytes, of events stored in memory, waiting to be sent over the
         /// network. Specify null for no limit.
         /// </param>
+        /// <param name="queueSizeLimit">The maximum number of events that will be held in-memory while waiting to be sent over the network.
+        /// Beyond this limit, events will be dropped. Specify null for no limit. Default value is null.</param>
         /// <param name="logEventLimitBytes">
         /// The maximum size, in bytes, for a serialized representation of a log event. Log events
         /// exceeding this size will be dropped. Specify null for no limit. Default value is null.
@@ -62,14 +64,14 @@ namespace Serilog
         /// characters added by the batch formatter, where the sequence of serialized log events
         /// are transformed into a payload, are not considered. Please make sure to accommodate for
         /// those.
-        /// <para />
+        /// <param />
         /// Another thing to mention is that although the sink does its best to optimize for this
         /// limit, if you decide to use an implementation of <seealso cref="IHttpClient"/> that is
         /// compressing the payload, e.g. <seealso cref="JsonGzipHttpClient"/>, this parameter
         /// describes the uncompressed size of the log events. The compressed size might be
         /// significantly smaller depending on the compression algorithm and the repetitiveness of
         /// the log events.
-        /// <para />
+        /// <param />
         /// Default value is null.
         /// </param>
         /// <param name="period">
@@ -106,6 +108,7 @@ namespace Serilog
             this LoggerSinkConfiguration sinkConfiguration,
             string requestUri,
             long? queueLimitBytes,
+            long? queueSizeLimit = null,
             long? logEventLimitBytes = null,
             int? logEventsInBatchLimit = 1000,
             long? batchSizeLimitBytes = null,
@@ -134,6 +137,7 @@ namespace Serilog
             var sink = new HttpSink(
                 requestUri: requestUri,
                 queueLimitBytes: queueLimitBytes,
+                queueSizeLimit: queueSizeLimit,
                 logEventLimitBytes: logEventLimitBytes,
                 logEventsInBatchLimit: logEventsInBatchLimit,
                 batchSizeLimitBytes: batchSizeLimitBytes,

--- a/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Http/LoggerSinkConfigurationExtensions.cs
@@ -64,14 +64,14 @@ namespace Serilog
         /// characters added by the batch formatter, where the sequence of serialized log events
         /// are transformed into a payload, are not considered. Please make sure to accommodate for
         /// those.
-        /// <param />
+        /// <para />
         /// Another thing to mention is that although the sink does its best to optimize for this
         /// limit, if you decide to use an implementation of <seealso cref="IHttpClient"/> that is
         /// compressing the payload, e.g. <seealso cref="JsonGzipHttpClient"/>, this parameter
         /// describes the uncompressed size of the log events. The compressed size might be
         /// significantly smaller depending on the compression algorithm and the repetitiveness of
         /// the log events.
-        /// <param />
+        /// <para />
         /// Default value is null.
         /// </param>
         /// <param name="period">

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
@@ -44,14 +44,14 @@ namespace Serilog.Sinks.Http.Private.NonDurable
         public HttpSink(
             string requestUri,
             long? queueLimitBytes,
-            long? queueSizeLimit,
             long? logEventLimitBytes,
             int? logEventsInBatchLimit,
             long? batchSizeLimitBytes,
             TimeSpan period,
             ITextFormatter textFormatter,
             IBatchFormatter batchFormatter,
-            IHttpClient httpClient)
+            IHttpClient httpClient,
+            long? queueSizeLimit = null)
         {
             this.requestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
             this.logEventLimitBytes = logEventLimitBytes;

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/NonDurable/HttpSink.cs
@@ -44,6 +44,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
         public HttpSink(
             string requestUri,
             long? queueLimitBytes,
+            long? queueSizeLimit,
             long? logEventLimitBytes,
             int? logEventsInBatchLimit,
             long? batchSizeLimitBytes,
@@ -62,7 +63,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
 
             connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
             timer = new PortableTimer(OnTick);
-            queue = new LogEventQueue(queueLimitBytes);
+            queue = new LogEventQueue(queueLimitBytes, queueSizeLimit);
 
             SetTimer();
         }

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/NonDurable/HttpSinkShould.cs
@@ -132,6 +132,7 @@ namespace Serilog.Sinks.Http.Private.NonDurable
 
             using var sink = new HttpSink(
                 requestUri: webServerFixture.RequestUri(testId),
+                queueLimitBytes: null,
                 queueSizeLimit: 1,
                 logEventLimitBytes: null,
                 logEventsInBatchLimit: null,

--- a/test/Serilog.Sinks.HttpTests/appsettings_http.json
+++ b/test/Serilog.Sinks.HttpTests/appsettings_http.json
@@ -7,6 +7,7 @@
         "Args": {
           "requestUri": "http://placeholder.com",
           "queueLimitBytes": null,
+          "queueSizeLimit": null,
           "logEventsInBatchLimit": 100,
           "batchSizeLimitBytes": 1048576,
           "period": "00:00:00.001",


### PR DESCRIPTION
# Description

Adds a new configuration to limit queue size by log events count

- Fixes #315 

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (must add parameter to the Wiki).
- [X] I have added tests that prove my fix is effective or that my feature works
