### PR TITLE
Propagate current trace and span ids through LogEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :zap: Added
+
+- [#409](https://github.com/FantasticFiasco/serilog-sinks-http/issues/409) Have `CompactTextFormatter`, `CompactRenderedTextFormatter`, `NamespacedTextFormatter`, `NormalTextFormatter` and `NormalRenderedTextFormatter` propagate the current trace and span id by writing the values into the JSON payload (contribution by [@consulting-dev](https://github.com/consulting-dev))
+
 ## [9.0.0] - 2024-04-14
 
 ### :zap: Added

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
@@ -115,6 +115,20 @@ public class CompactTextFormatter : ITextFormatter
             JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
         }
 
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"@tr\":\"");
+            output.Write(logEvent.TraceId.Value.ToHexString());
+            output.Write('\"');
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"@sp\":\"");
+            output.Write(logEvent.SpanId.Value.ToHexString());
+            output.Write('\"');
+        }
+
         foreach (var property in logEvent.Properties)
         {
             var name = property.Key;

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
@@ -101,18 +101,6 @@ public abstract class NamespacedTextFormatter : ITextFormatter
         output.Write("\",\"MessageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
-        if (logEvent.TraceId != null)
-        {
-            output.Write(",\"TraceId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
-        }
-
-        if (logEvent.SpanId != null)
-        {
-            output.Write(",\"SpanId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
-        }
-
         if (IsRenderingMessage)
         {
             output.Write(",\"RenderedMessage\":");
@@ -125,6 +113,18 @@ public abstract class NamespacedTextFormatter : ITextFormatter
         {
             output.Write(",\"Exception\":");
             JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
+
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
         }
 
         if (logEvent.Properties.Count != 0)

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
@@ -101,6 +101,18 @@ public abstract class NamespacedTextFormatter : ITextFormatter
         output.Write("\",\"MessageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
+        }
+
         if (IsRenderingMessage)
         {
             output.Write(",\"RenderedMessage\":");

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -77,6 +77,18 @@ public class NormalTextFormatter : ITextFormatter
         output.Write("\",\"MessageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
+        }
+
         if (IsRenderingMessage)
         {
             output.Write(",\"RenderedMessage\":");

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -77,18 +77,6 @@ public class NormalTextFormatter : ITextFormatter
         output.Write("\",\"MessageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
-        if (logEvent.TraceId != null)
-        {
-            output.Write(",\"TraceId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
-        }
-
-        if (logEvent.SpanId != null)
-        {
-            output.Write(",\"SpanId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
-        }
-
         if (IsRenderingMessage)
         {
             output.Write(",\"RenderedMessage\":");
@@ -101,6 +89,18 @@ public class NormalTextFormatter : ITextFormatter
         {
             output.Write(",\"Exception\":");
             JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
+
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString(), output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString(), output);
         }
 
         if (logEvent.Properties.Count != 0)

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/CompactTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/CompactTextFormatterShould.cs
@@ -268,7 +268,7 @@ public class CompactTextFormatterShould
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WriteTraceIdAndSpanId(bool isRenderingMessage)
+    public void WriteTraceAndSpanId(bool isRenderingMessage)
     {
         // Arrange
         logger = CreateLogger(isRenderingMessage ?

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/CompactTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/CompactTextFormatterShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -262,6 +263,37 @@ public class CompactTextFormatterShould
 
         // Assert
         output.ToString().ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteTraceIdAndSpanId(bool isRenderingMessage)
+    {
+        // Arrange
+        logger = CreateLogger(isRenderingMessage ?
+            new CompactRenderedTextFormatter() :
+            new CompactTextFormatter());
+
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+
+        // Act
+        logger.Write(
+            new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Information,
+                null,
+                MessageTemplate.Empty,
+                [],
+                traceId,
+                spanId));
+
+        // Assert
+        var logEvent = GetEvent();
+
+        logEvent["@tr"].ShouldBe(traceId.ToHexString());
+        logEvent["@sp"].ShouldBe(spanId.ToHexString());
     }
 
     private ILogger CreateLogger(ITextFormatter formatter)

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NamespacedTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NamespacedTextFormatterShould.cs
@@ -438,7 +438,7 @@ public class NamespacedTextFormatterShould
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WriteTraceIdAndSpanId(bool isRenderingMessage)
+    public void WriteTraceAndSpanId(bool isRenderingMessage)
     {
         // Arrange
         logger = CreateLogger(new Formatter("Foo", "Bar", isRenderingMessage));

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -276,6 +277,47 @@ public class NormalTextFormatterShould
 
         // Assert
         output.ToString().ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteTraceIdAndSpanId(bool isRenderingMessage)
+    {
+        // Arrange
+        const string activitySourceName = "Serilog.Sinks.HttpTests";
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+
+        // at least one listener must exist in order to start activity
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = source => source.Name == activitySourceName;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+
+        ActivitySource.AddActivityListener(listener);
+
+        using var customActivitySource = new ActivitySource(activitySourceName);
+        using var activity = customActivitySource.StartActivity("WriteTraceIdAndSpanId", ActivityKind.Server);
+        activity.ShouldNotBeNull();
+
+        logger = CreateLogger(isRenderingMessage ?
+            new NormalRenderedTextFormatter() :
+            new NormalTextFormatter());
+
+        // Act
+        logger.Information("No properties");
+
+        // Assert
+        var logEvent = GetEvent();
+
+        logEvent["Timestamp"].ShouldNotBeNull();
+        logEvent["Level"].ShouldBe("Information");
+        logEvent["TraceId"].ShouldBe(activity.TraceId.ToString());
+        logEvent["SpanId"].ShouldBe(activity.SpanId.ToString());
+        logEvent["MessageTemplate"].ShouldBe("No properties");
+        ((string)logEvent["RenderedMessage"]).ShouldBe(isRenderingMessage ? "No properties" : null);
+        logEvent["Exception"].ShouldBeNull();
+        logEvent["Properties"].ShouldBeNull();
+        logEvent["Renderings"].ShouldBeNull();
     }
 
     private ILogger CreateLogger(ITextFormatter formatter)

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
@@ -285,39 +285,29 @@ public class NormalTextFormatterShould
     public void WriteTraceIdAndSpanId(bool isRenderingMessage)
     {
         // Arrange
-        const string activitySourceName = "Serilog.Sinks.HttpTests";
-        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-
-        // at least one listener must exist in order to start activity
-        using var listener = new ActivityListener();
-        listener.ShouldListenTo = source => source.Name == activitySourceName;
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
-
-        ActivitySource.AddActivityListener(listener);
-
-        using var customActivitySource = new ActivitySource(activitySourceName);
-        using var activity = customActivitySource.StartActivity("WriteTraceIdAndSpanId", ActivityKind.Server);
-        activity.ShouldNotBeNull();
-
         logger = CreateLogger(isRenderingMessage ?
             new NormalRenderedTextFormatter() :
             new NormalTextFormatter());
 
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+
         // Act
-        logger.Information("No properties");
+        logger.Write(
+            new LogEvent(
+                DateTimeOffset.Now,
+                LogEventLevel.Information,
+                null,
+                MessageTemplate.Empty,
+                [],
+                traceId,
+                spanId));
 
         // Assert
         var logEvent = GetEvent();
 
-        logEvent["Timestamp"].ShouldNotBeNull();
-        logEvent["Level"].ShouldBe("Information");
-        logEvent["TraceId"].ShouldBe(activity.TraceId.ToString());
-        logEvent["SpanId"].ShouldBe(activity.SpanId.ToString());
-        logEvent["MessageTemplate"].ShouldBe("No properties");
-        ((string)logEvent["RenderedMessage"]).ShouldBe(isRenderingMessage ? "No properties" : null);
-        logEvent["Exception"].ShouldBeNull();
-        logEvent["Properties"].ShouldBeNull();
-        logEvent["Renderings"].ShouldBeNull();
+        logEvent["TraceId"].ShouldBe(traceId.ToString());
+        logEvent["SpanId"].ShouldBe(spanId.ToString());
     }
 
     private ILogger CreateLogger(ITextFormatter formatter)

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/TextFormatters/NormalTextFormatterShould.cs
@@ -282,7 +282,7 @@ public class NormalTextFormatterShould
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WriteTraceIdAndSpanId(bool isRenderingMessage)
+    public void WriteTraceAndSpanId(bool isRenderingMessage)
     {
         // Arrange
         logger = CreateLogger(isRenderingMessage ?


### PR DESCRIPTION
# Description

Activity class is essential part of distributed tracing and log correlation, see: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing. 

Activity class by default is created for each asp net request. It produces fields like TraceId and SpanId which helps to identify and correlate calls across multiple services (its automatically included by HttpClient as well) without writing any additional code.

So far emitting these fields was implemented few years ago in Serilog JsonFormatter, see: https://github.com/serilog/serilog/blob/dev/src/Serilog/Formatting/Json/JsonFormatter.cs#L74-L84 .

In my opinion - Http text formatters should also include these fields by default without a need to make custom overrides.
